### PR TITLE
Various Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $evervault->createRunToken($functionName = string, $data = array or object)
 | Parameter | Type   | Description                                          |
 | --------- | ------ | ---------------------------------------------------- |
 | `$functionName` | `string` | Name of the Function the Run Token should be created for |
-| `$data`      | `array` or `object` | Payload that the Run Token can be used with. If not provided, the payload will not be validated when the function is executed using the generated Run Token. |
+| `$data`      | `array` or `object` | Payload that the Run Token can be used with. This is an optional parameter. If not provided or the payload is an empty object, the Run Token will be valid for any payload. |
 
 ### $evervault->enableOutboundRelay
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $evervault->createRunToken($functionName = string, $data = array or object)
 | Parameter | Type   | Description                                          |
 | --------- | ------ | ---------------------------------------------------- |
 | `$functionName` | `string` | Name of the Function the Run Token should be created for |
-| `$data`      | `array` or `object` | Payload that the Run Token can be used with              |
+| `$data`      | `array` or `object` | Payload that the Run Token can be used with. If not provided, the payload will not be validated when the function is executed using the generated Run Token. |
 
 ### $evervault->enableOutboundRelay
 

--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -105,7 +105,7 @@ class Evervault {
         }
     }
 
-    public function createRunToken($functionName, $payload) {
+    public function createRunToken($functionName, $payload = []) {
         return $this->httpClient->createRunToken($functionName, $payload);
     }
 }

--- a/src/Evervault/EvervaultHttp.php
+++ b/src/Evervault/EvervaultHttp.php
@@ -98,6 +98,12 @@ class EvervaultHttp {
             )
         );
 
+        curl_setopt(
+            $this->curl,
+            CURLOPT_HTTPGET,
+            true
+        );
+        
         if (strtolower($method) === 'post') {
             curl_setopt(
                 $this->curl,


### PR DESCRIPTION
This PR includes the following changes:
- Reset the HTTP method on the open curl connection after sending a POST message. Without this change all requests occurring after a POST requests are populated as a POST.
- Add default value for payload when creating a run token. This is aligned with what is being done in other SDKs and provides a slightly better DX.