### PR TITLE
Fix outbound destination matching logic

### DIFF
--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -7,14 +7,14 @@ class Evervault {
     
     private $cryptoClient;
     private $httpClient;
-    public $configClient;
+    private $configClient;
     private $outboundRelayCaFile;
     private $outboundRelayCaPath;
     private $relayAuthString;
     private $appKeys;
     private $apiKey;
 
-    public $outboundRelayUrl;
+    private $outboundRelayUrl;
     private $outboundRelayCaUrl;
     private $outboundRelayDestinations;
     private $outboundRelayDestinationRegexes;

--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -7,16 +7,17 @@ class Evervault {
     
     private $cryptoClient;
     private $httpClient;
-    private $configClient;
+    public $configClient;
     private $outboundRelayCaFile;
     private $outboundRelayCaPath;
     private $relayAuthString;
     private $appKeys;
     private $apiKey;
 
-    private $outboundRelayUrl;
+    public $outboundRelayUrl;
     private $outboundRelayCaUrl;
     private $outboundRelayDestinations;
+    private $outboundRelayDestinationRegexes;
 
     private $caFilename = '/evervault-ca.pem';
 
@@ -96,9 +97,16 @@ class Evervault {
             $this->outboundRelayDestinations = $this->httpClient->getAppRelayConfiguration();
         }
 
+        if (!$this->outboundRelayDestinationRegexes) {
+            $this->outboundRelayDestinationRegexes = array_map(
+                'Evervault\EvervaultUtils::buildDomainRegexFromPattern',
+                $this->outboundRelayDestinations
+            );
+        }
+
         $requestUrl = curl_getinfo($curlHandler, CURLINFO_EFFECTIVE_URL);
 
-        if (EvervaultUtils::isDecryptionDomain($requestUrl, $this->outboundRelayDestinations)) {
+        if (EvervaultUtils::isDecryptionDomain($requestUrl, $this->outboundRelayDestinationRegexes)) {
             curl_setopt($curlHandler, CURLOPT_PROXY, $this->outboundRelayUrl);
             curl_setopt($curlHandler, CURLOPT_PROXYUSERPWD, $this->relayAuthString);
             curl_setopt($curlHandler, CURLOPT_CAINFO, $this->outboundRelayCaPath);

--- a/src/Evervault/EvervaultConfig.php
+++ b/src/Evervault/EvervaultConfig.php
@@ -3,12 +3,12 @@
 namespace Evervault;
 
 class EvervaultConfig {
-    public $apiBaseUrl = 'https://api.evervault.com';
-    public $functionRunBaseUrl = 'https://run.evervault.com';
+    public $apiBaseUrl;
+    public $functionRunBaseUrl;
 
-    public function _construct() {
-        $this->apiBaseUrl = getenv('EV_API_URL') || 'https://api.evervault.com';
-        $thus->functionRunBaseUrl = getenv('EV_CAGE_RUN_URL') || 'https://run.evervault.com';
+    function __construct() {
+        $this->apiBaseUrl = getenv('EV_API_URL') ? getenv('EV_API_URL') : 'https://api.evervault.com';
+        $this->functionRunBaseUrl = getenv('EV_CAGE_RUN_URL') ? getenv('EV_CAGE_RUN_URL') : 'https://run.evervault.com';
     }
 
     public function getApiBaseUrl() {

--- a/src/Evervault/EvervaultUtils.php
+++ b/src/Evervault/EvervaultUtils.php
@@ -17,17 +17,27 @@ class EvervaultUtils {
         return preg_replace('/={1,2}$/', '', $base64);
     }
 
-    public static function isDecryptionDomain($domain, $decryptionDomains) {
+    public static function isDecryptionDomain($domain, $decryptionDomainRegexes) {
         $domain = parse_url($domain)['host'];
 
-        foreach ($decryptionDomains as $decryptionDomain) {
-            if ($decryptionDomain === $domain) {
-                return true;
-            } else if (substr($decryptionDomain, 0, 1) === '*' && str_ends_with($domain, substr($decryptionDomain, 1))) {
+        foreach ($decryptionDomainRegexes as $decryptionDomainRegex) {
+            if (preg_match($decryptionDomainRegex, $domain)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    public static function buildDomainRegexFromPattern($pattern) {
+        // Replace globstars with their new equivalent
+        $pattern = preg_replace('/(?<!\\*)\\*\\*+\\./', '*', $pattern);
+        // Escape dots
+        $pattern = preg_replace('/\\./', '\.', $pattern);
+        // Turn stars into regexes
+        $pattern = preg_replace('/(?<!\\*)\\*+/', '.*', $pattern);
+        // Convert *domain patterns to match subdomains and the domain itself
+        $pattern = preg_replace('/(\\.\\*)([^\\\\*.])/', '$1(^|\\.)$2', $pattern);
+        return '/^'.$pattern.'$/i';
     }
 }


### PR DESCRIPTION
# Why

The domain matching logic in the SDK and as described in the UI were out of sync.
Matching was also being done case sensitively.

# How

Build regex corresponding to matching rules described in the UI, which is cached when the once the outbound cache is (re)generated.

As there's no existing test framework for the PHP SDK I am least confident that this has no edge cases, so it is marked as a draft.
