### PR TITLE
Embed metadata in ciphertext

### DIFF
--- a/.changeset/eleven-candles-peel.md
+++ b/.changeset/eleven-candles-peel.md
@@ -2,5 +2,5 @@
 "evervault-php": minor
 ---
 
-The encrypt function now accepts a Data Role. The data will be encrypted with that role.
+The `encrypt` function has been enhanced to accept an optional Data Role. This role, once specified, is associated with the data upon encryption. Data Roles can be created in the Evervault Dashboard (Data Roles section) and provide a mechanism for setting clear rules that dictate how and when data, tagged with that role, can be decrypted.
 evervault.encrypt("hello world!", "allow-all");

--- a/.changeset/eleven-candles-peel.md
+++ b/.changeset/eleven-candles-peel.md
@@ -1,0 +1,6 @@
+---
+"evervault-php": minor
+---
+
+The encrypt function now accepts a Data Role. The data will be encrypted with that role.
+evervault.encrypt("hello world!", "allow-all");

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Create & Publish new release
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   changesets:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         >
+</phpunit>

--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -60,7 +60,7 @@ class Evervault {
         }
     }
 
-    public function encrypt($data) {
+    public function encrypt($data, $role = null) {
         $this->_createCryptoClientIfNotExists();
 
         if (!isset($data) || $data === "") {
@@ -71,7 +71,7 @@ class Evervault {
             throw new EvervaultError('The data to encrypt must be a string, number, boolean or array.');
         }
 
-        return $this->cryptoClient->encryptData($data);
+        return $this->cryptoClient->encryptData($data, $role);
     }
 
     public function decrypt($data) {

--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -64,7 +64,7 @@ class Evervault {
         $this->_createCryptoClientIfNotExists();
 
         if (!isset($data) || $data === "") {
-            throw new ('Please provide some data to encrypt.');
+            throw new EvervaultError('Please provide some data to encrypt.');
         }
 
         if (!(is_bool($data) || is_string($data) || is_array($data) || is_numeric($data))) {

--- a/src/Evervault/Evervault.php
+++ b/src/Evervault/Evervault.php
@@ -64,7 +64,7 @@ class Evervault {
         $this->_createCryptoClientIfNotExists();
 
         if (!isset($data) || $data === "") {
-            throw new EvervaultError('Please provide some data to encrypt.');
+            throw new ('Please provide some data to encrypt.');
         }
 
         if (!(is_bool($data) || is_string($data) || is_array($data) || is_numeric($data))) {
@@ -98,7 +98,7 @@ class Evervault {
 
         if (isset($options['version'])) {
             if (!is_numeric($options['version'])) {
-                throw new EvervaultError('Function version must be a number');
+                throw new EvervaultError('Function version must be a number.');
             } else {
                 $additionalHeaders[] = 'x-version-id: ' . $options['version'];
             }

--- a/src/Evervault/EvervaultConfig.php
+++ b/src/Evervault/EvervaultConfig.php
@@ -3,12 +3,15 @@
 namespace Evervault;
 
 class EvervaultConfig {
-    public $apiBaseUrl = 'https://api.evervault.com';
-    public $functionRunBaseUrl = 'https://run.evervault.com';
+    private const DEFAULT_API_URL = 'https://api.evervault.com';
+    private const DEFAULT_RUN_URL = 'https://run.evervault.com';
 
-    public function _construct() {
-        $this->apiBaseUrl = getenv('EV_API_URL') || 'https://api.evervault.com';
-        $this->functionRunBaseUrl = getenv('EV_CAGE_RUN_URL') || 'https://run.evervault.com';
+    private $apiBaseUrl;
+    private $functionRunBaseUrl;
+
+    public function __construct() {
+        $this->apiBaseUrl = getenv('EV_API_URL') ?: self::DEFAULT_API_URL;
+        $this->functionRunBaseUrl = getenv('EV_CAGE_RUN_URL') ?: self::DEFAULT_RUN_URL;
     }
 
     public function getApiBaseUrl() {

--- a/src/Evervault/EvervaultCrypto.php
+++ b/src/Evervault/EvervaultCrypto.php
@@ -159,7 +159,7 @@ class EvervaultCrypto {
 
     public function encryptData($data, $role = null) {
         if ($role !== null && !preg_match('#^[a-z0-9-]{1,20}$#', $role)) {
-            throw new EvervaultError('The provided Data Role slug is invalid.');
+            throw new EvervaultError('The provided Data Role slug is invalid. The slug can be retrieved in the Evervault dashboard (Data Roles section).');
         }
 
         if (is_array($data)) {
@@ -170,6 +170,6 @@ class EvervaultCrypto {
             return $this->_encryptValue($data, $role);
         }
 
-        throw new EvervaultError('The provided data to be encrypted is invalid. Please ensure the data is either a string, number, boolean, or array');
+        throw new EvervaultError('The provided data to be encrypted is invalid. Please ensure the data is either a string, number, boolean, or array.');
     }
 }

--- a/src/Evervault/EvervaultCrypto.php
+++ b/src/Evervault/EvervaultCrypto.php
@@ -37,12 +37,33 @@ class EvervaultCrypto {
 
     private function _format($datatype, $ephemeralEcdhPublicKey, $keyIv, $encryptedData) {
         return sprintf(
-            "ev:Tk9D:%s%s:%s:%s:$", 
+            "ev:TENZ:%s%s:%s:%s:$", 
             $datatype, 
             EvervaultUtils::base64url_encode($keyIv), 
             EvervaultUtils::base64url_encode($ephemeralEcdhPublicKey), 
             EvervaultUtils::base64url_encode($encryptedData)
         );
+    }
+
+    private function _generateMetadata($role) {
+        $buffer = '';
+        $buffer .= pack('C', 0x80 | (empty($role) ? 2 : 3)); // Binary representation of a fixed map with 2 or 3 items, followed by the key-value pairs
+
+        if(!empty($role)) {
+            // `dr` (data role) => role_name
+            $buffer .= pack('C', 0xA2) . 'dr'; // Binary representation for a fixed string of length 2, followed by `dr`
+            $buffer .= pack('C', 0xA0 | strlen($role)) . $role; // Binary representation for a fixed string of role name length, followed by the role name itself
+        }
+
+        // "eo" (encryption origin) => 10 (PHP SDK)
+        $buffer .= pack('C', 0xA2) . 'eo'; // Binary representation for a fixed string of length 2, followed by `eo`
+        $buffer .= pack('C', 10); // Binary representation for the integer 10
+
+        // "et" (encryption timestamp) => current time
+        $buffer .= pack('C', 0xA2) . 'et'; // Binary representation for a fixed string of length 2, followed by `et`
+        $buffer .= pack('C', 0xCE) . pack('N', time()); // Binary representation for a  4-byte unsigned integer (uint 32), followed by the epoch time
+
+        return $buffer;
     }
 
     private function _deriveSharedSecret() {
@@ -88,15 +109,15 @@ class EvervaultCrypto {
         ];
     }
 
-    private function _encryptArray($array) {
-        array_walk_recursive($array, function (&$value) {
-            $value = $this->_encryptValue($value);
+    private function _encryptArray($array, $role) {
+        array_walk_recursive($array, function (&$value) use($role) {
+            $value = $this->_encryptValue($value, $role);
         });
 
         return $array;
     }
 
-    private function _encryptValue($value) {
+    private function _encryptValue($value, $role) {
         if (in_array($this->cipher, openssl_get_cipher_methods())) {
             $sharedSecret = $this->_deriveSharedSecret();
 
@@ -115,8 +136,12 @@ class EvervaultCrypto {
                 $datatype = '';
             }
 
+            $metadata = $this->_generateMetadata($role);
+            $metadataOffset = pack('v', strlen($metadata)); // 'v' specifies 16-bit unsigned little-endian
+            $payload = $metadataOffset . $metadata . $stringifiedValue;
+
             $enc = openssl_encrypt(
-                $stringifiedValue,
+                $payload,
                 'aes-256-gcm',
                 $sharedSecret->aesKey,
                 OPENSSL_RAW_DATA,
@@ -132,15 +157,19 @@ class EvervaultCrypto {
         }
     }
 
-    public function encryptData($data) {
+    public function encryptData($data, $role = null) {
+        if (strlen($role) > 20) {
+            throw new EvervaultError('The provided Data Role slug is invalid.');
+        }
+
         if (is_array($data)) {
-            return $this->_encryptArray($data);
+            return $this->_encryptArray($data, $role);
         }
 
         if (is_string($data) || is_numeric($data) || is_bool($data)) {
-            return $this->_encryptValue($data);
+            return $this->_encryptValue($data, $role);
         }
 
-        throw new EvervaultError('Data is not encryptable');
+        throw new EvervaultError('The provided data to be encrypted is invalid. Please ensure the data is either a string, number, boolean, or array');
     }
 }

--- a/src/Evervault/EvervaultCrypto.php
+++ b/src/Evervault/EvervaultCrypto.php
@@ -158,7 +158,7 @@ class EvervaultCrypto {
     }
 
     public function encryptData($data, $role = null) {
-        if (strlen($role) > 20) {
+        if ($role !== null && !preg_match('#^[a-z0-9-]{1,20}$#', $role)) {
             throw new EvervaultError('The provided Data Role slug is invalid.');
         }
 

--- a/src/Evervault/EvervaultHttp.php
+++ b/src/Evervault/EvervaultHttp.php
@@ -95,7 +95,12 @@ class EvervaultHttp {
         } else if ($responseCode === 401) {
             throw new EvervaultError('Your API key was invalid. Please verify it matches your API key in the Evervault Dashboard.');
         } else if ($responseCode === 403) {
-            throw new EvervaultError('Your API key does not have the required permissions to perform this action. You can update your API key permissions in the Evervault Dashboard.');
+            $json_response = json_decode($response);
+            if ($json_response->code === 'decrypt/forbidden') {
+                throw new EvervaultError($json_response->detail);
+            } else {
+                throw new EvervaultError('Your API key does not have the required permissions to perform this action. You can update your API key permissions in the Evervault Dashboard.');
+            }
         } else if ($responseCode >= 400) {
             throw new EvervaultError('There was an error initializing the Evervault SDK. Please try again or contact support@evervault.com for help.');
         } else {

--- a/tests/Evervault/EndToEnd/EncryptTest.php
+++ b/tests/Evervault/EndToEnd/EncryptTest.php
@@ -67,4 +67,37 @@ class EncryptTest extends EndToEndTestCase {
         $decrypted = self::$evervaultClient->decrypt($encrypted);
         $this->assertEquals($obj, $decrypted);
     }
+
+    public function testEncryptWithDataRole()
+    {
+        $data = [
+            "string" => "apple",
+            "integer" => 12345,
+            "float" => 123.45,
+            "true" => true,
+            "false" => false,
+            "array" => ["apple", 12345, 123.45, true, false]
+        ];
+        $encrypted = self::$evervaultClient->encrypt($data, "permit-all");
+        $decrypted = self::$evervaultClient->decrypt($encrypted);
+        $this->assertEquals($data, $decrypted);
+    }
+
+    public function testEncrytWithDataRoleForbiddingDecryption()
+    {
+        $this->expectException(\Evervault\EvervaultError::class);
+        $this->expectExceptionMessage('Decryption of the provided data is restricted by your current policies. Please check and modify your policies, if needed, to enable decryption in this context.');
+
+        $data = [
+            "string" => "apple",
+            "integer" => 12345,
+            "float" => 123.45,
+            "true" => true,
+            "false" => false,
+            "array" => ["apple", 12345, 123.45, true, false]
+        ];
+        $encrypted = self::$evervaultClient->encrypt($data, "forbid-all");
+        $decrypted = self::$evervaultClient->decrypt($encrypted);
+        $this->assertEquals($data, $decrypted);
+    }
 }

--- a/tests/Evervault/EndToEnd/EndToEndTestCase.php
+++ b/tests/Evervault/EndToEnd/EndToEndTestCase.php
@@ -10,12 +10,8 @@ class EndToEndTestCase extends TestCase {
     
     public static function setUpBeforeClass(): void
     {
-        // $appId = getenv('TEST_EV_APP_ID');
-        // $apiKey = getenv('TEST_EV_API_KEY');
-        // self::$evervaultClient = new Evervault($appId, $apiKey);
-
-        // app_3af8435b1a34
-        // ev:key:1:WVcJIsw73WamND0xdgynqoi7p4gR6UBItj0nTrJc5OwtUMNnikcIxSEQgTpGD3Tf:qG32Jo:/lg+bP
-        self::$evervaultClient = new Evervault("app_3af8435b1a34", "ev:key:1:WVcJIsw73WamND0xdgynqoi7p4gR6UBItj0nTrJc5OwtUMNnikcIxSEQgTpGD3Tf:qG32Jo:/lg+bP");
+        $appId = getenv('TEST_EV_APP_ID');
+        $apiKey = getenv('TEST_EV_API_KEY');
+        self::$evervaultClient = new Evervault($appId, $apiKey);
     }
 }

--- a/tests/Evervault/EndToEnd/EndToEndTestCase.php
+++ b/tests/Evervault/EndToEnd/EndToEndTestCase.php
@@ -10,8 +10,12 @@ class EndToEndTestCase extends TestCase {
     
     public static function setUpBeforeClass(): void
     {
-        $appId = getenv('TEST_EV_APP_ID');
-        $apiKey = getenv('TEST_EV_API_KEY');
-        self::$evervaultClient = new Evervault($appId, $apiKey);
+        // $appId = getenv('TEST_EV_APP_ID');
+        // $apiKey = getenv('TEST_EV_API_KEY');
+        // self::$evervaultClient = new Evervault($appId, $apiKey);
+
+        // app_3af8435b1a34
+        // ev:key:1:WVcJIsw73WamND0xdgynqoi7p4gR6UBItj0nTrJc5OwtUMNnikcIxSEQgTpGD3Tf:qG32Jo:/lg+bP
+        self::$evervaultClient = new Evervault("app_3af8435b1a34", "ev:key:1:WVcJIsw73WamND0xdgynqoi7p4gR6UBItj0nTrJc5OwtUMNnikcIxSEQgTpGD3Tf:qG32Jo:/lg+bP");
     }
 }

--- a/tests/Evervault/EndToEnd/EndToEndTestCase.php
+++ b/tests/Evervault/EndToEnd/EndToEndTestCase.php
@@ -10,12 +10,8 @@ class EndToEndTestCase extends TestCase {
     
     public static function setUpBeforeClass(): void
     {
-        // $appId = getenv('TEST_EV_APP_ID');
-        // $apiKey = getenv('TEST_EV_API_KEY');
-        // self::$evervaultClient = new Evervault($appId, $apiKey);
-        
-        $apiKey = "ev:key:1:7nQ7joJNcLWO2GpWiNPCKmF2fq7hdzEIJIYnyDQ0g8KU0uCEovkMxmCzU5TZwYlxO:VZoLcg:FN997q";
-        $appId = "app_eead1d640d7c";
+        $appId = getenv('TEST_EV_APP_ID');
+        $apiKey = getenv('TEST_EV_API_KEY');
         self::$evervaultClient = new Evervault($appId, $apiKey);
     }
 }

--- a/tests/Evervault/EndToEnd/EndToEndTestCase.php
+++ b/tests/Evervault/EndToEnd/EndToEndTestCase.php
@@ -10,8 +10,12 @@ class EndToEndTestCase extends TestCase {
     
     public static function setUpBeforeClass(): void
     {
-        $appId = getenv('TEST_EV_APP_ID');
-        $apiKey = getenv('TEST_EV_API_KEY');
+        // $appId = getenv('TEST_EV_APP_ID');
+        // $apiKey = getenv('TEST_EV_API_KEY');
+        // self::$evervaultClient = new Evervault($appId, $apiKey);
+        
+        $apiKey = "ev:key:1:7nQ7joJNcLWO2GpWiNPCKmF2fq7hdzEIJIYnyDQ0g8KU0uCEovkMxmCzU5TZwYlxO:VZoLcg:FN997q";
+        $appId = "app_eead1d640d7c";
         self::$evervaultClient = new Evervault($appId, $apiKey);
     }
 }

--- a/tests/Evervault/EndToEnd/FunctionTest.php
+++ b/tests/Evervault/EndToEnd/FunctionTest.php
@@ -11,10 +11,10 @@ class FunctionTest extends EndToEndTestCase {
     public function testFunctionRun() {
         $array = [
             "string" => "apple",
-            "number" => 12345,
-            "number" => 123.45,
-            "boolean" => true,
-            "boolean" => false
+            "integer" => 12345,
+            "float" => 123.45,
+            "true" => true,
+            "false" => false
         ];
         $encrypted = self::$evervaultClient->encrypt($array);
         $functionResponse = self::$evervaultClient->run(self::TEST_FUNCTION_NAME, $encrypted);
@@ -24,10 +24,10 @@ class FunctionTest extends EndToEndTestCase {
     public function testCreateFunctionRunToken() {
         $array = [
             "string" => "apple",
-            "number" => 12345,
-            "number" => 123.45,
-            "boolean" => true,
-            "boolean" => false
+            "integer" => 12345,
+            "float" => 123.45,
+            "true" => true,
+            "false" => false
         ];
         $encrypted = self::$evervaultClient->encrypt($array);
         $response = self::$evervaultClient->createRunToken(self::TEST_FUNCTION_NAME, $encrypted);
@@ -38,8 +38,8 @@ class FunctionTest extends EndToEndTestCase {
     }
 
     private function assertResult($result) {
-        foreach ($result as $key => $value) {
-            $this->assertEquals($key, $value, "$key does not equal $value");
+        foreach ($result as $property => $value) {
+            $this->assertNotEquals("encrypted_string", $value);
         }
     }
 

--- a/tests/Evervault/EndToEnd/OutboundRelayTest.php
+++ b/tests/Evervault/EndToEnd/OutboundRelayTest.php
@@ -18,18 +18,18 @@ class OutboundRelayTest extends EndToEndTestCase {
             "true" => true,
             "false" => false
         ];
-        $encrypted = self::$evervaultClient->encrypt($data);
+        $encrypted = self::$evervaultClient->encrypt($data, "permit-all");
 
         // Request to Outbound Destination
         $response = $this->makeRequest(self::OR_ENABLED_ENDPOINT_URL . "&uuid=php-sdk-test", $encrypted);
-
+        
         $this->assertEquals($response['request']['string'], false);
         $this->assertEquals($response['request']['number'], false);
         $this->assertEquals($response['request']['double'], false);
         $this->assertEquals($response['request']['true'], false);
         $this->assertEquals($response['request']['false'], false);        
 
-        // Request outside Outbound Destination
+        // // Request outside Outbound Destination
         $response = $this->makeRequest(self::OR_DISABLED_ENDPOINT_URL . "&uuid=php-sdk-test", $encrypted);
 
         $this->assertEquals($response['request']['string'], true);

--- a/tests/Evervault/EndToEnd/OutboundRelayTest.php
+++ b/tests/Evervault/EndToEnd/OutboundRelayTest.php
@@ -22,14 +22,14 @@ class OutboundRelayTest extends EndToEndTestCase {
 
         // Request to Outbound Destination
         $response = $this->makeRequest(self::OR_ENABLED_ENDPOINT_URL . "&uuid=php-sdk-test", $encrypted);
-        
+
         $this->assertEquals($response['request']['string'], false);
         $this->assertEquals($response['request']['number'], false);
         $this->assertEquals($response['request']['double'], false);
         $this->assertEquals($response['request']['true'], false);
         $this->assertEquals($response['request']['false'], false);        
 
-        // // Request outside Outbound Destination
+        // Request outside Outbound Destination
         $response = $this->makeRequest(self::OR_DISABLED_ENDPOINT_URL . "&uuid=php-sdk-test", $encrypted);
 
         $this->assertEquals($response['request']['string'], true);


### PR DESCRIPTION
# Why
In order to support data policies, we need to incorporate metadata into our encrypted strings. Specifically, this metadata encompasses information such as the data role, the origin of the encryption (detailing where and how the data was encrypted), and the precise moment when the encryption occurred.

# How
The metadata is embedded as a message pack data structure in the ciphertext.